### PR TITLE
Check if a model is disposed before fetching its version

### DIFF
--- a/src/monaco-marker-data-provider.ts
+++ b/src/monaco-marker-data-provider.ts
@@ -67,7 +67,7 @@ export function registerMarkerDataProvider(
     const versionId = model.getVersionId()
     const markers = await provider.provideMarkerData(model)
     // The model may have been updated disposed by the time marker data has been fetched.
-    if (versionId === model.getVersionId() && !model.isDisposed() && matchesLanguage(model)) {
+    if (!model.isDisposed() && versionId === model.getVersionId() && matchesLanguage(model)) {
       monaco.editor.setModelMarkers(model, provider.owner, markers ?? [])
     }
   }


### PR DESCRIPTION
We ran into the same issue described in https://github.com/remcohaszing/monaco-marker-data-provider/issues/1 and we are on version 1.2.3 (where the fix is supposed to be). This issue is that `model.getVersionId()` throws the same error. 

Instead this PR switches the check of `model.isDisposed()` to before `model.getVersionId()`. If the model is disposed then the condition will short-circuit and `model.getVersionId()` will never get called.